### PR TITLE
Aggiorna vista partner_firstname per Odoo 18

### DIFF
--- a/partner_firstname/views/base_config_view.xml
+++ b/partner_firstname/views/base_config_view.xml
@@ -5,23 +5,31 @@
         <field name="inherit_id" ref="base_setup.res_config_settings_view_form" />
         <field name="arch" type="xml">
             <xpath expr="//div[@id='companies']" position='after'>
-                <block
-                    title="Partner Names Order"
-                    name="partner_names_order_setting_container"
-                >
-                    <setting>
-                        <field name="partner_names_order" nolabel="1" />
-                        <field name="partner_names_order_changed" invisible="1" />
-                        <button
-                            name="action_recalculate_partners_name"
-                            string="Recalculate names"
-                            icon="fa-play"
-                            type="object"
-                            help="Recalculate names for all partners. This process could take so much time if there are more than 10,000 active partners"
-                            invisible="not partner_names_order_changed"
-                        />
-                    </setting>
-                </block>
+                <h2>Partner Names Order</h2>
+                <div class="row mt16 o_settings_container" name="partner_names_order_setting_container">
+                    <div class="col-xs-12 col-md-6 o_setting_box">
+                        <div class="o_setting_left_pane">
+                            <field name="partner_names_order" />
+                        </div>
+                        <div class="o_setting_right_pane">
+                            <label for="partner_names_order" />
+                            <div class="text-muted">
+                                Configure how partner names are displayed
+                            </div>
+                            <div class="content-group mt16" invisible="not partner_names_order_changed">
+                                <field name="partner_names_order_changed" invisible="1" />
+                                <button
+                                    name="action_recalculate_partners_name"
+                                    string="Recalculate names"
+                                    icon="fa-play"
+                                    type="object"
+                                    class="btn-secondary"
+                                    help="Recalculate names for all partners. This process could take so much time if there are more than 10,000 active partners"
+                                />
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Refactor `partner_firstname` configuration view to Odoo 18.0 `o_setting_box` syntax for compatibility.

---

[Open in Web](https://cursor.com/agents?id=bc-0ed3996b-4386-46a0-9a4b-c3a2fb309360) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-0ed3996b-4386-46a0-9a4b-c3a2fb309360) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)